### PR TITLE
画像選択ボタンが画面幅によってはみ出てしまっていたので `max-width: 100%` を付与

### DIFF
--- a/src/components/GyazoUploadFormComponent.js
+++ b/src/components/GyazoUploadFormComponent.js
@@ -69,7 +69,7 @@ class GyazoUploadFormComponent extends React.Component {
             <img className='card-img-top img-responsive' ref='image' src={this.state.imageUri || ''} style={{display: this.state.imageUri ? 'inline-block' : 'none'}}/>
             <div className='card-block'>
               <label className='file' htmlFor='gyazo-image' style={{display: this.state.imageUri ? 'none' : 'inline-block', maxWidth: '100%'}}>
-                <input className='file' id='gyazo-image' name='imagedata' onChange={this.handleChange.bind(this)} ref='gyazoImageData' required={true} type='file'/>
+                <input className='file' id='gyazo-image' name='imagedata' onChange={this.handleChange.bind(this)} ref='gyazoImageData' required={true} style={{maxWidth: '100%'}} type='file'/>
                 <span className='file-custom'/>
               </label>
               {((imageUri) => {


### PR DESCRIPTION
iPhone 5s で変な空白が出てしまうので、とりあえずの対処。
