### PR TITLE
eslint のルールを追加

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,11 @@
 {
   "parser": "babel-eslint",
+  "extends": "eslint:recommended",
   "env": {
     "browser": true,
     "node": true
   },
   "rules": {
+    "no-unused-vars": 0
   }
 }


### PR DESCRIPTION
`eslint`によるlintがシンタックスエラー以外を検出していないように感じるので調査の上、適切なルールを`.eslint`に追加させる。
