### PR TITLE
依存ライブラリーから holder.js を取り除くのを忘れていた

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "gulp-replace": "^0.5.4",
     "gulp-rev": "^6.0.1",
     "gulp-uglify": "^1.4.2",
-    "holderjs": "^2.9.0",
     "koa": "^2.0.0-alpha.3",
     "koa-convert": "^1.0.0",
     "koa-static": "^1.5.2",

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,5 @@
 import 'babel-polyfill';
 import 'whatwg-fetch';
-import 'holderjs';
 import ReactDOM from 'react-dom';
 import { createElementWithContext } from 'fluxible-addons-react';
 import application from './application';


### PR DESCRIPTION
[holder.js](https://www.npmjs.com/package/holderjs) は結局使わないことにしたのに依存関係から取り除くのを忘れてしまっていたので削除。
