### PR TITLE
stone-skin を使ったモデルで storeName や property が正しく設定できていなかった

### DIFF
--- a/src/models/GyazoService.js
+++ b/src/models/GyazoService.js
@@ -3,23 +3,27 @@ import StoneSkin from 'stone-skin/with-tv4';
 const Base = StoneSkin[typeof window !== 'undefined' ? 'IndexedDb' : 'MemoryDb'];
 
 class GyazoService extends Base {
-  storeName: 'GyazoService';
+  get storeName() {
+    return 'GyazoService';
+  }
 
-  schema: {
-    properties: {
-      name: {
-        type: 'string'
-      },
-      uri: {
-        type: 'string'
-      },
-      gyazoId: {
-        type: 'string'
-      },
-      useProxy: {
-        type: 'boolean'
+  get schema() {
+    return {
+      properties: {
+        name: {
+          type: 'string'
+        },
+        uri: {
+          type: 'string'
+        },
+        gyazoId: {
+          type: 'string'
+        },
+        useProxy: {
+          type: 'boolean'
+        }
       }
-    }
+    };
   }
 }
 


### PR DESCRIPTION
[README](https://github.com/mizchi/stone-skin/blob/c559a9b41ec262515bcc5c26afeee92ae52af539/README.md) の記述では `babel-core` 6.1.2 で正常動作をさせられない模様。getter を使って対処したがもう少しスマートなやりようはありそう。
