### PR TITLE
ImageStore に値を入れる際に既存のものを上書きさせるように

### DIFF
--- a/src/stores/ImageStore.js
+++ b/src/stores/ImageStore.js
@@ -15,7 +15,7 @@ class ImageStore extends BaseStore {
     if (Array.isArray(images) && images.length <= 0) {
       return;
     }
-    this.images = this.images.concat(images);
+    this.images = [].concat(images);
     this.emitChange();
   }
 


### PR DESCRIPTION
表示時に要素に対し `key` の指定を行っていたために重複は発生していなかったが、情報として不整合が起きてしまっていた。
