### PR TITLE
アップロード直後の画像は ImageStore の先頭に追加させるように

### DIFF
--- a/src/actions/saveUploadedImageAction.js
+++ b/src/actions/saveUploadedImageAction.js
@@ -6,7 +6,7 @@ let saveUploadedImageAction = async (context, payload) => {
   let image = new Image();
   await image.ready;
   let images = [await image.save({ fileName, uri, uploadedAt })];
-  context.dispatch('SET_UPLOADED_IMAGES', { images });
+  context.dispatch('PREPEND_UPLOADED_IMAGES', { images });
 };
 
 export default saveUploadedImageAction;

--- a/src/stores/ImageStore.js
+++ b/src/stores/ImageStore.js
@@ -3,12 +3,18 @@ import { BaseStore } from 'fluxible/addons';
 class ImageStore extends BaseStore {
   static storeName = 'ImageStore';
   static handlers = {
+    PREPEND_UPLOADED_IMAGES: 'prependUploadedImages',
     SET_UPLOADED_IMAGES: 'setUploadedImages'
   }
 
   constructor(dispacher) {
     super(dispacher);
     this.images = [];
+  }
+
+  prependUploadedImages({ images }) {
+    this.images = [].concat(images, this.images);
+    this.emitChange();
   }
 
   setUploadedImages({ images }) {


### PR DESCRIPTION
画像をアップロードした際の `ImageStore` への格納はページロード時のものと共通のアクションを使うべきではなかった。
