### PR TITLE
アップロードする画像の選択をした際に readyState を unsent に変更させる

### DIFF
--- a/src/components/GyazoUploadFormComponent.js
+++ b/src/components/GyazoUploadFormComponent.js
@@ -73,7 +73,7 @@ class GyazoUploadFormComponent extends React.Component {
       return false;
     }
     let imageUri = URL.createObjectURL(file);
-    this.setState({ imageUri });
+    this.setState({ readyState: 'unsent', imageUri });
     return false;
   }
 


### PR DESCRIPTION
一度画像をアップロードすると `readyState` が `done` になり、二度目の画像アップロードができなくなってしまっていた。なので、画像選択時に `readyState` を初期化させるように。
