### PR TITLE
画像のアップロード処理時にエラー処理を行わせるように

### DIFF
--- a/src/actions/selectUnsentImageFile.js
+++ b/src/actions/selectUnsentImageFile.js
@@ -1,0 +1,9 @@
+async function selectUnsentImageFile(context, { imageFile }) {
+  let imageUri = URL.createObjectURL(imageFile);
+  context.dispatch('HANDLE_READY_STATE_CHANGE', {
+    readyState: 'unsent',
+    imageUri
+  });
+}
+
+export default selectUnsentImageFile;

--- a/src/actions/showAlertAction.js
+++ b/src/actions/showAlertAction.js
@@ -1,0 +1,5 @@
+async function showAlertAction(context, { type, message }) {
+  context.dispatch('SET_ALERT_MESSAGE', { type, message });
+}
+
+export default showAlertAction;

--- a/src/actions/uploadImageAction.js
+++ b/src/actions/uploadImageAction.js
@@ -1,0 +1,30 @@
+import saveUploadedImageAction from './saveUploadedImageAction';
+
+async function uploadImageAction(context, { uri, gyazoId, imageFile }) {
+  let formData = new FormData();
+  formData.append('id', gyazoId);
+  formData.append('imagedata', imageFile);
+  let request = new Request(uri, {
+    method: 'POST',
+    body: formData
+  });
+  context.dispatch('HANDLE_READY_STATE_CHANGE', {
+    readyState: 'opened'
+  });
+  let response = await fetch(request);
+  context.dispatch('HANDLE_READY_STATE_CHANGE', {
+    readyState: 'loading'
+  });
+  let imageUri = await response.text();
+  context.dispatch('HANDLE_READY_STATE_CHANGE', {
+    readyState: 'done',
+    imageUri: null
+  });
+  await context.executeAction(saveUploadedImageAction, {
+    fileName: imageFile.name,
+    uri: imageUri,
+    uploadedAt: new Date()
+  });
+}
+
+export default uploadImageAction;

--- a/src/actions/uploadImageAction.js
+++ b/src/actions/uploadImageAction.js
@@ -1,6 +1,7 @@
 import saveUploadedImageAction from './saveUploadedImageAction';
 
-async function uploadImageAction(context, { uri, gyazoId, imageFile }) {
+async function uploadImageAction(context, { uri, gyazoId, imageFile, form }) {
+  let imageUri;
   let formData = new FormData();
   formData.append('id', gyazoId);
   formData.append('imagedata', imageFile);
@@ -11,20 +12,34 @@ async function uploadImageAction(context, { uri, gyazoId, imageFile }) {
   context.dispatch('HANDLE_READY_STATE_CHANGE', {
     readyState: 'opened'
   });
-  let response = await fetch(request);
-  context.dispatch('HANDLE_READY_STATE_CHANGE', {
-    readyState: 'loading'
-  });
-  let imageUri = await response.text();
-  context.dispatch('HANDLE_READY_STATE_CHANGE', {
-    readyState: 'done',
-    imageUri: null
-  });
-  await context.executeAction(saveUploadedImageAction, {
-    fileName: imageFile.name,
-    uri: imageUri,
-    uploadedAt: new Date()
-  });
+  try {
+    let response = await fetch(request);
+    context.dispatch('HANDLE_READY_STATE_CHANGE', {
+      readyState: 'loading'
+    });
+    imageUri = await response.text();
+    await context.executeAction(saveUploadedImageAction, {
+      fileName: imageFile.name,
+      uri: imageUri,
+      uploadedAt: new Date()
+    });
+    imageUri = null;
+    form.reset();
+    context.dispatch('SET_ALERT_MESSAGE', {
+      type: 'success',
+      message: 'Upload image has been completed.'
+    })
+  } catch (error) {
+    context.dispatch('SET_ALERT_MESSAGE', {
+      type: 'danger',
+      message: 'Failed to upload image.'
+    });
+  } finally {
+    context.dispatch('HANDLE_READY_STATE_CHANGE', {
+      readyState: 'done',
+      imageUri
+    });
+  }
 }
 
 export default uploadImageAction;

--- a/src/application.js
+++ b/src/application.js
@@ -2,6 +2,7 @@ import Fluxible from 'fluxible';
 import ApplicationComponent from './components/ApplicationComponent';
 import RouteStore from './stores/RouteStore';
 import ErrorStore from './stores/ErrorStore';
+import AlertStore from './stores/AlertStore';
 import GyazoServiceStore from './stores/GyazoServiceStore';
 import UploadImageStore from './stores/UploadImageStore';
 import ImageStore from './stores/ImageStore';
@@ -11,6 +12,7 @@ let application = new Fluxible({
   stores: [
     RouteStore,
     ErrorStore,
+    AlertStore,
     GyazoServiceStore,
     UploadImageStore,
     ImageStore

--- a/src/application.js
+++ b/src/application.js
@@ -3,6 +3,7 @@ import ApplicationComponent from './components/ApplicationComponent';
 import RouteStore from './stores/RouteStore';
 import ErrorStore from './stores/ErrorStore';
 import GyazoServiceStore from './stores/GyazoServiceStore';
+import UploadImageStore from './stores/UploadImageStore';
 import ImageStore from './stores/ImageStore';
 
 let application = new Fluxible({
@@ -11,6 +12,7 @@ let application = new Fluxible({
     RouteStore,
     ErrorStore,
     GyazoServiceStore,
+    UploadImageStore,
     ImageStore
   ]
 });

--- a/src/components/AlertComponent.js
+++ b/src/components/AlertComponent.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { connectToStores } from 'fluxible-addons-react';
+import AlertStore from '../stores/AlertStore';
+import showAlertAction from '../actions/showAlertAction';
+
+class AlertComponent extends React.Component {
+  static contextTypes = {
+    executeAction: React.PropTypes.func.isRequired,
+    getStore: React.PropTypes.func.isRequired
+  };
+
+  static propTypes = {
+    type: React.PropTypes.string,
+    message: React.PropTypes.string
+  };
+
+  static defaultProps = {
+    type: 'info',
+    message: null
+  };
+
+  handleClick() {
+    this.context.executeAction(showAlertAction, {
+      type: 'info',
+      message: null
+    });
+  }
+
+  render() {
+    return (
+      <div className='AlertComponent'>
+        <div className={`alert alert-${this.props.type}`} role='alert' style={{ display: this.props.message ? 'block' : 'none' }}>
+          <button className='close' data-dissmiss='alert' data-label='Close' onClick={this.handleClick.bind(this)} type='button'>
+            <span aria-hidden='true'>&times;</span>
+            <span className='sr-only'>Close</span>
+          </button>
+          <span>{this.props.message}</span>
+        </div>
+      </div>
+    );
+  }
+}
+
+AlertComponent = connectToStores(AlertComponent, [AlertStore], (context) => {
+  let alertStore = context.getStore(AlertStore);
+  return {
+    type: alertStore.getCurrentType(),
+    message: alertStore.getCurrentMessage()
+  };
+});
+export default AlertComponent;

--- a/src/components/ApplicationComponent.js
+++ b/src/components/ApplicationComponent.js
@@ -3,6 +3,7 @@ import { provideContext, connectToStores } from 'fluxible-addons-react';
 import { handleHistory } from 'fluxible-router';
 import ErrorHandler from '../handlers/ErrorHandler';
 import NavigationComponent from './NavigationComponent';
+import AlertComponent from './AlertComponent';
 import ErrorStore from '../stores/ErrorStore';
 
 //@handleHistory
@@ -17,11 +18,11 @@ class ApplicationComponent extends React.Component {
   }
 
   render() {
-
     return (
       <div id='ApplicationComponent'>
         <NavigationComponent/>
         <div className='container'>
+          <AlertComponent/>
           {this.getHandler()}
         </div>
       </div>

--- a/src/components/GyazoUploadFormComponent.js
+++ b/src/components/GyazoUploadFormComponent.js
@@ -39,9 +39,9 @@ class GyazoUploadFormComponent extends React.Component {
     this.context.executeAction(uploadImageAction, {
       uri: this.props.uri,
       gyazoId: this.props.gyazoId,
-      imageFile
+      imageFile,
+      form
     });
-    form.reset();
     return false;
   }
 
@@ -53,6 +53,10 @@ class GyazoUploadFormComponent extends React.Component {
     }
     this.context.executeAction(selectUnsentImageFile, { imageFile });
     return false;
+  }
+
+  canSubmit() {
+    return ['unsent', 'done'].includes(this.props.readyState);
   }
 
   render() {
@@ -67,11 +71,11 @@ class GyazoUploadFormComponent extends React.Component {
                 <span className='file-custom'/>
               </label>
               {((imageUri) => imageUri && (
-                <button className='btn btn-primary' disabled={this.props.readyState !== 'unsent'} type='submit'>
-                  {((readyState) => readyState !== 'unsent' && (
+                <button className='btn btn-primary' disabled={!this.canSubmit()} type='submit'>
+                  {((readyState) => !this.canSubmit() && (
                     <i className='fa fa-spin fa-spinner'/>
                   ))(this.props.readyState)}
-                  <span className='label'>{this.props.readyState === 'unsent' ? 'Upload' : 'Uploading...'}</span>
+                  <span className='label'>{this.canSubmit() ? 'Upload' : 'Uploading...'}</span>
                   </button>
               ))(this.props.imageUri)}
             </div>

--- a/src/components/GyazoUploadFormComponent.js
+++ b/src/components/GyazoUploadFormComponent.js
@@ -1,10 +1,10 @@
 import uuid from 'uuid';
 import React from 'react';
 import { connectToStores } from 'fluxible-addons-react';
+import UploadImageStore from '../stores/UploadImageStore';
 import ImageStore from '../stores/ImageStore';
-import saveUploadedImageAction from '../actions/saveUploadedImageAction';
-
-const EXTERNAL_URI_PATTERN = /^https?:\/\//;
+import selectUnsentImageFile from '../actions/selectUnsentImageFile';
+import uploadImageAction from '../actions/uploadImageAction';
 
 class GyazoUploadFormComponent extends React.Component {
   static contextTypes = {
@@ -13,67 +13,45 @@ class GyazoUploadFormComponent extends React.Component {
   };
 
   static propTypes = {
-    id: React.PropTypes.string,
-    uri: React.PropTypes.string.isRequired,
     gyazoId: React.PropTypes.string.isRequired,
+    id: React.PropTypes.string,
+    imageUri: React.PropTypes.string,
+    readyState: React.PropTypes.string.isRequired,
+    uri: React.PropTypes.string.isRequired,
     useProxy: React.PropTypes.bool.isRequired
-  }
+  };
 
   static defaultProps = {
-    uri: 'https://gyazo.com/upload.cgi',
     gyazoId: '',
+    imageUri: null,
+    readyState: 'unsent',
+    uri: 'https://gyazo.com/upload.cgi',
     useProxy: true
-  }
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      readyState: 'unsent',
-      imageUri: null
-    };
-  }
+  };
 
   handleSubmit(event) {
     event.preventDefault();
-    let image = (this.refs.gyazoImageData.files || [])[0];
-    if (!(image instanceof File)) {
+    let form = event.target;
+    let imageFile = (this.refs.gyazoImageData.files || [])[0];
+    if (!(imageFile instanceof File)) {
       return false;
     }
-    let fileName = image.name;
-    let form = event.target;
-    let formData = new FormData();
-    formData.append('id', this.props.gyazoId);
-    formData.append('imagedata', image);
-    let request = new Request(this.props.uri, {
-      method: event.target.method,
-      body: formData
+    this.context.executeAction(uploadImageAction, {
+      uri: this.props.uri,
+      gyazoId: this.props.gyazoId,
+      imageFile
     });
-    (async () => {
-      this.setState({ readyState: 'opened' });
-      let response = await fetch(request);
-      this.setState({ readyState: 'loading' });
-      let imageUri = await response.text();
-      let uploadedAt = new Date();
-      this.setState({ readyState: 'done', imageUri });
-      this.context.executeAction(saveUploadedImageAction, {
-        fileName,
-        uri: imageUri,
-        uploadedAt
-      });
-    })();
     form.reset();
     return false;
   }
 
   handleChange(event) {
     event.preventDefault();
-    let { target: { files: [file, ..._] } } = event;
-    if (typeof file === 'undefined') {
+    let { target: { files: [imageFile, ..._] } } = event;
+    if (typeof imageFile === 'undefined') {
       return false;
     }
-    let imageUri = URL.createObjectURL(file);
-    this.setState({ readyState: 'unsent', imageUri });
+    this.context.executeAction(selectUnsentImageFile, { imageFile });
     return false;
   }
 
@@ -82,20 +60,20 @@ class GyazoUploadFormComponent extends React.Component {
       <div className='GyazoUploadFormComponent'>
         <form className='form-horizontal' method='post' onSubmit={this.handleSubmit.bind(this)}>
           <fieldset className='card'>
-            <img className='card-img-top img-responsive' ref='image' src={this.state.imageUri || ''} style={{display: this.state.imageUri && !EXTERNAL_URI_PATTERN.test(this.state.imageUri) ? 'inline-block' : 'none'}}/>
+            <img className='card-img-top img-responsive' ref='image' src={this.props.imageUri || ''} style={{display: this.props.imageUri ? 'inline-block' : 'none'}}/>
             <div className='card-block'>
-              <label className='file' htmlFor='gyazo-image' style={{display: this.state.imageUri && !EXTERNAL_URI_PATTERN.test(this.state.imageUri) ? 'none' : 'inline-block', maxWidth: '100%'}}>
+              <label className='file' htmlFor='gyazo-image' style={{display: this.props.imageUri ? 'none' : 'inline-block', maxWidth: '100%'}}>
                 <input className='file' id='gyazo-image' name='imagedata' onChange={this.handleChange.bind(this)} ref='gyazoImageData' required={true} style={{maxWidth: '100%'}} type='file'/>
                 <span className='file-custom'/>
               </label>
-              {((imageUri) => imageUri && !EXTERNAL_URI_PATTERN.test(imageUri) && (
-                <button className='btn btn-primary' disabled={this.state.readyState !== 'unsent'} type='submit'>
+              {((imageUri) => imageUri && (
+                <button className='btn btn-primary' disabled={this.props.readyState !== 'unsent'} type='submit'>
                   {((readyState) => readyState !== 'unsent' && (
                     <i className='fa fa-spin fa-spinner'/>
-                  ))(this.state.readyState)}
-                  <span className='label'>{this.state.readyState === 'unsent' ? 'Upload' : 'Uploading...'}</span>
+                  ))(this.props.readyState)}
+                  <span className='label'>{this.props.readyState === 'unsent' ? 'Upload' : 'Uploading...'}</span>
                   </button>
-              ))(this.state.imageUri)}
+              ))(this.props.imageUri)}
             </div>
           </fieldset>
         </form>
@@ -104,6 +82,11 @@ class GyazoUploadFormComponent extends React.Component {
   }
 }
 
-GyazoUploadFormComponent = connectToStores(GyazoUploadFormComponent, [ImageStore], (context) => ({
-}));
+GyazoUploadFormComponent = connectToStores(GyazoUploadFormComponent, [UploadImageStore], (context) => {
+  let uploadImageStore = context.getStore(UploadImageStore);
+  return {
+    readyState: uploadImageStore.readyState,
+    imageUri: uploadImageStore.imageUri
+  };
+});
 export default GyazoUploadFormComponent;

--- a/src/stores/AlertStore.js
+++ b/src/stores/AlertStore.js
@@ -1,0 +1,41 @@
+import { BaseStore } from 'fluxible/addons';
+
+class AlertStore extends BaseStore {
+  static storeName = 'AlertStore';
+  static handlers = {
+    SET_ALERT_MESSAGE: 'setAlertMessage'
+  };
+
+  constructor(dispatcher) {
+    super(dispatcher);
+
+    this.type = 'info';
+    this.message = null;
+  }
+
+  setAlertMessage({ type, message }) {
+    this.type = type || 'info';
+    this.message = message;
+    this.emitChange();
+  }
+
+  getCurrentType() {
+    return this.type;
+  }
+
+  getCurrentMessage() {
+    return this.message;
+  }
+
+  dehydrate() {
+    return {
+      message: this.getCurrentMessage()
+    };
+  }
+
+  rehydrate(state) {
+    this.message = state.message;
+  }
+}
+
+export default AlertStore;

--- a/src/stores/UploadImageStore.js
+++ b/src/stores/UploadImageStore.js
@@ -1,0 +1,47 @@
+import { BaseStore } from 'fluxible/addons';
+
+class UploadImageStore extends BaseStore {
+  static storeName = 'UploadImageStore';
+  static handlers = {
+    HANDLE_READY_STATE_CHANGE: 'handleReadyStateChange'
+  };
+
+  constructor(dispatcher) {
+    super(dispatcher);
+
+    this.readyState = 'unsent';
+    this.imageUri = null;
+  }
+
+  handleReadyStateChange({ readyState, imageUri }) {
+    if (typeof readyState !== 'undefined') {
+      this.readyState = readyState;
+    }
+    if (typeof imageUri !== 'undefined') {
+      this.imageUri = imageUri;
+    }
+    this.emitChange();
+  }
+
+  getCurrentReadyState() {
+    return this.readyState;
+  }
+
+  getCurrentImageUri() {
+    return this.imageUri;
+  }
+
+  dehydrate() {
+    return {
+      readyState: this.getCurrentReadyState(),
+      imageUri: this.getCurrentImageUri()
+    }
+  }
+
+  rehydrate(state) {
+    this.readyState = state.readyState;
+    this.imageUri = state.imageUri;
+  }
+}
+
+export default UploadImageStore;


### PR DESCRIPTION
現状は画像のアップロードが失敗となり、処理が途中でおわらせられてしまったとしても、処理が続いているように見えてしまっている。明らかに良くないので、適切なエラー処理を行わせるようにする。
