### PR TITLE
Gyazo に処理を投げるときにちゃんとエラー処理を行うように

### DIFF
--- a/src/actions/uploadImageAction.js
+++ b/src/actions/uploadImageAction.js
@@ -17,6 +17,11 @@ async function uploadImageAction(context, { uri, gyazoId, imageFile, form }) {
     context.dispatch('HANDLE_READY_STATE_CHANGE', {
       readyState: 'loading'
     });
+    if (response.status !== 200) {
+      let error = new Error(response.statusText);
+      error.statusCode = response.status;
+      throw error;
+    }
     imageUri = await response.text();
     await context.executeAction(saveUploadedImageAction, {
       fileName: imageFile.name,

--- a/src/actions/uploadImageAction.js
+++ b/src/actions/uploadImageAction.js
@@ -1,5 +1,13 @@
 import saveUploadedImageAction from './saveUploadedImageAction';
 
+function validateUri(uri) {
+  let inputField = document.createElement('input');
+  inputField.type = 'uri';
+  inputField.value = uri;
+  let validity = inputField.validity;
+  return validity.valid;
+}
+
 async function uploadImageAction(context, { uri, gyazoId, imageFile, form }) {
   let imageUri;
   let formData = new FormData();
@@ -23,6 +31,10 @@ async function uploadImageAction(context, { uri, gyazoId, imageFile, form }) {
       throw error;
     }
     imageUri = await response.text();
+    if (!validateUri(imageUri)) {
+      let error = new Error('Invalid URI.');
+      throw error;
+    }
     await context.executeAction(saveUploadedImageAction, {
       fileName: imageFile.name,
       uri: imageUri,


### PR DESCRIPTION
404 を返されていてもそのまま素通ししてしまっていた。

また URI 以外のものが返っていても素直にそのまま成功したと判断し、IndexedDB に情報を格納してしまっていたので URI として正しいか検証するように。
