### PR TITLE
PNG 画像以外を選択することができないように

### DIFF
--- a/src/components/GyazoUploadFormComponent.js
+++ b/src/components/GyazoUploadFormComponent.js
@@ -67,7 +67,7 @@ class GyazoUploadFormComponent extends React.Component {
             <img className='card-img-top img-responsive' ref='image' src={this.props.imageUri || ''} style={{display: this.props.imageUri ? 'inline-block' : 'none'}}/>
             <div className='card-block'>
               <label className='file' htmlFor='gyazo-image' style={{display: this.props.imageUri ? 'none' : 'inline-block', maxWidth: '100%'}}>
-                <input className='file' id='gyazo-image' name='imagedata' onChange={::this.handleChange} ref='gyazoImageData' style={{maxWidth: '100%'}} type='file'/>
+                <input accept='image/png' className='file' id='gyazo-image' name='imagedata' onChange={::this.handleChange} ref='gyazoImageData' style={{maxWidth: '100%'}} type='file'/>
                 <span className='file-custom'/>
               </label>
               {((imageUri) => imageUri && (


### PR DESCRIPTION
画像の選択時に PNG 以外のフォーマットのものを選択したときは PNG に変換した上でアップロードするようにしたいが、とりあえずは考えないことにして PNG 以外をそもそも選択できないように。
