### PR TITLE
Fix typo `uri` => `url`

### DIFF
--- a/src/actions/uploadImageAction.js
+++ b/src/actions/uploadImageAction.js
@@ -2,7 +2,7 @@ import saveUploadedImageAction from './saveUploadedImageAction';
 
 function validateUri(uri) {
   let inputField = document.createElement('input');
-  inputField.type = 'uri';
+  inputField.type = 'url';
   inputField.value = uri;
   let validity = inputField.validity;
   return validity.valid;


### PR DESCRIPTION
しょうもないtypoの修正。`HTMLInputElement` の `type` 属性が持てる値は `uri` ではなく `url`。
