### PR TITLE
npm start で起動させられるように

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./bin/gyazo-web-client
+web: npm start

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   },
   "scripts": {
     "build": "gulp build",
+    "dev": "nodemon --exec babel-node ./bin/gyazo-web-client.js",
     "lint": "gulp lint",
     "postinstall": "npm run build",
-    "start": "nodemon --exec babel-node ./bin/gyazo-web-client.js",
+    "start": "./bin/gyazo-web-client",
     "watch": "gulp watch"
   },
   "dependencies": {


### PR DESCRIPTION
`npm start` で `babel-node` を経由させた開発環境用のサーバーを起動させていたが、そちらは `npm run dev` にして、`npm start` では build 済のものが実行されるように。
