### PR TITLE
`async function` で無名関数を使わないように

### DIFF
--- a/src/actions/handleErrorAction.js
+++ b/src/actions/handleErrorAction.js
@@ -1,5 +1,5 @@
-let handleErrorAction = async (context, payload) => {
+async function handleErrorAction(context, payload) {
   context.dispatch('HANDLE_ERROR', payload);
-};
+}
 
 export default handleErrorAction;

--- a/src/actions/loadUploadedImagesAction.js
+++ b/src/actions/loadUploadedImagesAction.js
@@ -1,10 +1,10 @@
 import Image from '../models/Image';
 
-let loadUploadedImagesAction = async (context, payload) => {
+async function loadUploadedImagesAction(context, payload) {
   let image = new Image();
   await image.ready;
   let images = await image.all();
   context.dispatch('SET_UPLOADED_IMAGES', { images });
-};
+}
 
 export default loadUploadedImagesAction;

--- a/src/actions/saveUploadedImageAction.js
+++ b/src/actions/saveUploadedImageAction.js
@@ -1,12 +1,12 @@
 import Image from '../models/Image';
 
-let saveUploadedImageAction = async (context, payload) => {
+async function saveUploadedImageAction(context, payload) {
   let { fileName, uri } = payload;
   let uploadedAt = (payload.uploadedAt instanceof Date ? payload.uploadedAt : new Date()).toJSON();
   let image = new Image();
   await image.ready;
   let images = [await image.save({ fileName, uri, uploadedAt })];
   context.dispatch('PREPEND_UPLOADED_IMAGES', { images });
-};
+}
 
 export default saveUploadedImageAction;


### PR DESCRIPTION
`async function` を

``` javascript
let funcName = async () => {
  // ...
};
```

のような形で無名関数を変数に入れる形として使っていた箇所があったが

``` javascript
async function funcName() {
  // ...
}
```

のように正しく関数として宣言されるように。
