### PR TITLE
gulp のタスクから config/routes.js のチェックを排除

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -53,13 +53,12 @@ gulp.task('build:client', ['lint'], function() {
 });
 
 gulp.task('lint', function() {
-  return gulp.src(['./config/routes.js', './src/**/*.js'])
+  return gulp.src(['./src/**/*.js'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
 });
 
 gulp.task('watch', ['build:client'], function() {
-  gulp.watch('./config/routes.js', ['build:client']);
   gulp.watch('./src/**/*.js', ['build:client']);
 });


### PR DESCRIPTION
config/routes.js はもう使われておらず、不要なチェックをしてしまっていた。
