### PR TITLE
サーバー用のリソースはビルドさせないように

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@
 /npm-debug.log
 
 /bin/gyazo-web-client
-/lib/*
-!/lib/.keep
 /public/*
 !/public/.keep

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -13,20 +13,7 @@ import buffer from 'vinyl-buffer';
 
 const DEBUG = env.NODE_ENV !== 'production';
 
-gulp.task('build', ['build:server', 'build:client']);
-
-gulp.task('build:server', function() {
-  var sources = [];
-  sources.push(gulp.src('./src/**/*.js')
-    .pipe(babel())
-    .pipe(gulp.dest('./lib')));
-  sources.push(gulp.src('./bin/gyazo-web-client.js')
-     .pipe(replace(/import\s(.+)\sfrom\s'\.\.\/src\/(.+)';/, (_, m, f) =>
-       (`import 'babel-polyfill';\nimport ${f} from '../lib/${m}';\n`)))
-    .pipe(babel())
-    .pipe(rename('gyazo-web-client'))
-    .pipe(gulp.dest('./bin')));
-});
+gulp.task('build', ['build:client']);
 
 gulp.task('build:client', ['lint'], function() {
   let src = browserify({

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "nodemon --exec babel-node ./bin/gyazo-web-client.js",
     "lint": "gulp lint",
     "postinstall": "npm run build",
-    "start": "./bin/gyazo-web-client",
+    "start": "node start",
     "watch": "gulp watch"
   },
   "dependencies": {
@@ -29,6 +29,7 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
+    "babel-register": "^6.2.0",
     "babelify": "^7.2.0",
     "browserify": "^12.0.1",
     "eslint": "^1.10.3",

--- a/start.js
+++ b/start.js
@@ -1,0 +1,3 @@
+require('babel-register');
+require('babel-polyfill');
+require('./bin/gyazo-web-client');


### PR DESCRIPTION
`require('babel-register');` を使ってゴリゴリと済ませるように。
