### PR TITLE
携帯電話以外ではナビゲーションバーにある設定ページへのリンクにラベルを表示させる

### DIFF
--- a/src/components/NavigationComponent.js
+++ b/src/components/NavigationComponent.js
@@ -21,6 +21,7 @@ class NavigationComponent extends React.Component {
             <li className='nav-item'>
               <NavLink className='nav-link' routeName='settings'>
                 <i className='fa fa-cog fa-lg'/>
+                <span className='hidden-xs-down'>&nbsp;Settings</span>
               </NavLink>
             </li>
           </ul>


### PR DESCRIPTION
タイトルのまんま。携帯電話ではアイコンのみの表示で、それ以外の環境では「Settings」というラベルが表示されているほうがクリックもしやすく、またわかりやすい。
