### PR TITLE
PNG 以外の画像を PNG に変換してからアップロードするように

### DIFF
--- a/src/actions/selectUnsentImageFile.js
+++ b/src/actions/selectUnsentImageFile.js
@@ -1,4 +1,9 @@
+import convertImageFormatToPng from '../utils/convertImageFormatToPng';
+
 async function selectUnsentImageFile(context, { imageFile }) {
+  if (imageFile.type !== 'image/png') {
+    imageFile = await convertImageFormatToPng(imageFile);
+  }
   let imageUri = URL.createObjectURL(imageFile);
   context.dispatch('SET_IMAGE_FILE', { imageFile });
   context.dispatch('HANDLE_READY_STATE_CHANGE', {

--- a/src/actions/uploadImageAction.js
+++ b/src/actions/uploadImageAction.js
@@ -36,7 +36,7 @@ async function uploadImageAction(context, { uri, gyazoId, imageFile }) {
       throw error;
     }
     await context.executeAction(saveUploadedImageAction, {
-      fileName: imageFile.name,
+      fileName: imageFile.name || '',
       uri: imageUri,
       uploadedAt: new Date()
     });

--- a/src/components/GyazoUploadFormComponent.js
+++ b/src/components/GyazoUploadFormComponent.js
@@ -42,7 +42,7 @@ class GyazoUploadFormComponent extends React.Component {
   handleSubmit(event) {
     event.preventDefault();
     let imageFile = this.props.imageFile;
-    if (!(imageFile instanceof File)) {
+    if (!(imageFile instanceof File || imageFile instanceof Blob)) {
       return false;
     }
     this.context.executeAction(uploadImageAction, {
@@ -75,7 +75,7 @@ class GyazoUploadFormComponent extends React.Component {
             <img className='card-img-top img-responsive' ref='image' src={this.props.imageUri || ''} style={{display: this.props.imageUri ? 'inline-block' : 'none'}}/>
             <div className='card-block'>
               <label className='file' htmlFor='gyazo-image' style={{display: this.props.imageUri ? 'none' : 'inline-block', maxWidth: '100%'}}>
-                <input accept='image/png' className='file' id='gyazo-image' name='imagedata' onChange={::this.handleChange} ref='gyazoImageData' style={{maxWidth: '100%'}} type='file'/>
+                <input accept='image/*' className='file' id='gyazo-image' name='imagedata' onChange={::this.handleChange} ref='gyazoImageData' style={{maxWidth: '100%'}} type='file'/>
                 <span className='file-custom'/>
               </label>
               {((imageUri) => imageUri && (

--- a/src/stores/UploadImageStore.js
+++ b/src/stores/UploadImageStore.js
@@ -30,6 +30,7 @@ class UploadImageStore extends BaseStore {
 
   setImageFile({ imageFile }) {
     this.imageFile = imageFile;
+    this.emitChange();
   }
 
   getCurrentImageFile() {

--- a/src/utils/convertImageFormatToPng.js
+++ b/src/utils/convertImageFormatToPng.js
@@ -1,0 +1,47 @@
+function convertImageFormatToPng(imageFile) {
+  let imageUri = URL.createObjectURL(imageFile);
+  let imageElement = document.createElement('img');
+  let canvasElement = document.createElement('canvas');
+  let canvasContext = canvasElement.getContext('2d');
+  return new Promise((resolve, reject) => {
+    imageElement.addEventListener('load', () => {
+      canvasElement.width = imageElement.width;
+      canvasElement.height = imageElement.height;
+      canvasContext.drawImage(imageElement, 0, 0);
+      try {
+        let dataUri = canvasElement.toDataURL('image/png');
+        let blob = dataUriToBlob(dataUri);
+        resolve(blob);
+      } catch (error) {
+        reject(error);
+      }
+    });
+    imageElement.addEventListener('error', reject);
+    imageElement.src = imageUri;
+  });
+}
+
+function dataUriToBlob(uri) {
+  let colonPosition = uri.indexOf(':');
+  let protocol = uri.slice(0, colonPosition + 1);
+  if (protocol !== 'data:') {
+    throw new Error('URI is not data URI.');
+  }
+  let uriWithoutProtocol = uri.slice(colonPosition + 1);
+  let [ mediaType, data ] = uriWithoutProtocol.split(',', 2);
+  let [ type, ...parameters ] = mediaType.split(';');
+  let isEncodedBase64 = parameters.includes('base64');
+  return new Blob([isEncodedBase64 ? decodeBase64(data) : data], { type });
+}
+
+function decodeBase64(data) {
+  let bytes = atob(data);
+  let length = bytes.length;
+  let u8a = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    u8a[i] = bytes.charCodeAt(i);
+  }
+  return u8a;
+}
+
+export default convertImageFormatToPng;


### PR DESCRIPTION
`canvas` 要素を通して PNG 以外のフォーマットの画像を PNG に変換させる。

`HTMLCanvasElement.prototype.toBlob` メソッドをそのまま使えれば良かったのだが、Google Chrome 48ではなぜか `File` オブジェクトを返されうまく動かすことができなかったため愚直に data URI から `Blob` オブジェクトの変換を行っている。

(この処理を書いたの何回目だろう……)
