### PR TITLE
Firefox だと `atob` が非常に遅いので自前で実装するように

### DIFF
--- a/src/utils/convertImageFormatToPng.js
+++ b/src/utils/convertImageFormatToPng.js
@@ -1,13 +1,16 @@
+import decodeBase64 from './decodeBase64';
+
 function convertImageFormatToPng(imageFile) {
   let imageUri = URL.createObjectURL(imageFile);
   let imageElement = document.createElement('img');
   let canvasElement = document.createElement('canvas');
   let canvasContext = canvasElement.getContext('2d');
   return new Promise((resolve, reject) => {
-    imageElement.addEventListener('load', () => {
-      canvasElement.width = imageElement.width;
-      canvasElement.height = imageElement.height;
-      canvasContext.drawImage(imageElement, 0, 0);
+    imageElement.addEventListener('load', function() {
+      URL.revokeObjectURL(this.src);
+      canvasElement.width = this.width;
+      canvasElement.height = this.height;
+      canvasContext.drawImage(this, 0, 0);
       try {
         let dataUri = canvasElement.toDataURL('image/png');
         let blob = dataUriToBlob(dataUri);
@@ -31,17 +34,11 @@ function dataUriToBlob(uri) {
   let [ mediaType, data ] = uriWithoutProtocol.split(',', 2);
   let [ type, ...parameters ] = mediaType.split(';');
   let isEncodedBase64 = parameters.includes('base64');
-  return new Blob([isEncodedBase64 ? decodeBase64(data) : data], { type });
-}
-
-function decodeBase64(data) {
-  let bytes = atob(data);
-  let length = bytes.length;
-  let u8a = new Uint8Array(length);
-  for (let i = 0; i < length; i++) {
-    u8a[i] = bytes.charCodeAt(i);
-  }
-  return u8a;
+  /* eslint no-console: 0 */
+  console.time('decodeBase64');
+  data = isEncodedBase64 ? decodeBase64(data) : data;
+  console.timeEnd('decodeBase64');
+  return new Blob([data], { type });
 }
 
 export default convertImageFormatToPng;

--- a/src/utils/decodeBase64.js
+++ b/src/utils/decodeBase64.js
@@ -1,0 +1,25 @@
+const characters = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'];
+const DECODE_BASE64_TABLE = [];
+for (let [code, character] of characters.entries()) {
+  DECODE_BASE64_TABLE[character.charCodeAt(0)] = code;
+}
+DECODE_BASE64_TABLE['='.charCodeAt(0)] = 0;
+
+function decodeBase64(source) {
+  let sourceLength = source.length;
+  let padding = source.slice(sourceLength - 2).split('=').length - 1;
+  let length = Math.floor((sourceLength + 3) / 4) * 3 - padding;
+  let result = new Uint8Array(length);
+  for (let cursor = 0, i = 0; i < sourceLength; cursor += 3, i += 4) {
+    let bits = DECODE_BASE64_TABLE[source[i].charCodeAt(0)] << 18
+      | DECODE_BASE64_TABLE[source[i + 1].charCodeAt(0)] << 12
+      | DECODE_BASE64_TABLE[source[i + 2].charCodeAt(0)] << 6
+      | DECODE_BASE64_TABLE[source[i + 3].charCodeAt(0)];
+    result[cursor] = (bits >> 16) & 0xff;
+    result[cursor + 1] = (bits >> 8) & 0xff;
+    result[cursor + 2] = bits & 0xff;
+  }
+  return result;
+}
+
+export default decodeBase64;


### PR DESCRIPTION
`atob` で変換した値をループで回して `Uint8Array` のインスタンスに入れ込むようにしていたが Firefox だと異常に遅くなってしまっていたので、Base64 のデコードを自前で実装するようにした。十分の一くらいの速度になり、ほかのウェブブラウザとの致命的な速度差はなくなったように見える。
