### PR TITLE
直近にアップロードした画像のみを表示させるように

### DIFF
--- a/src/actions/loadUploadedImagesAction.js
+++ b/src/actions/loadUploadedImagesAction.js
@@ -4,6 +4,10 @@ async function loadUploadedImagesAction(context, payload) {
   let image = new Image();
   await image.ready;
   let images = await image.all();
+  images.sort((previousImage, image) =>
+    previousImage.uploadedAt < image.uploadedAt ? 1 : -1
+  );
+  images = images.slice(0, 24);
   context.dispatch('SET_UPLOADED_IMAGES', { images });
 }
 

--- a/src/stores/ImageStore.js
+++ b/src/stores/ImageStore.js
@@ -27,9 +27,6 @@ class ImageStore extends BaseStore {
 
   getImages() {
     let images = [].concat(this.images);
-    images.sort((previousImage, image) =>
-      previousImage.uploadedAt < image.uploadedAt ? 1 : -1
-    );
     return images;
   }
 


### PR DESCRIPTION
アップロード画面にアップロードした画像を一覧表示させていたが画像が多くなりすぎると早晩破綻することは明白なので、直近の二十四件のみを表示させるよ
うにした。

ページ送り、もしくは autopager ができるようにするべきだが、とりあえずはかんがえないことに。
